### PR TITLE
qt: Fix missing qRegisterMetaType for size_t

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -66,6 +66,8 @@ int main(int argc, char *argv[])
         setenv("QT_QPA_PLATFORM", "minimal", /* overwrite */ 0);
     #endif
 
+    qRegisterMetaType<size_t>("size_t");
+
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests
     BitcoinApplication app(*node);


### PR DESCRIPTION
This fixes the error output in checks.
```
QWARN  : AppTests::appTests() QObject::connect: Cannot queue arguments of type 'size_t'
```
Fixed in.

https://github.com/bitcoin/bitcoin/pull/17427
